### PR TITLE
Add pip installation command to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,3 +136,9 @@ recursively by default. Any attempt to set attributes on the wrapped object will
     <Immutable SomethingElse: <SomethingElse: blue>>
 
 You can toggle the recursive immutability by specifying the 'recursive' flag.
+
+Installation (via pip)
+++++++++++++++++++++++
+
+    pip install utils
+


### PR DESCRIPTION
I found the project interesting & useful. And I believe it would be helpful to have the pip package name in the readme.