### PR TITLE
#28 (and #23) a fix to stop .../tests/* being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author='Haak Saxberg',
     author_email='haak.erling@gmail.com',
     url='http://github.com/haaksmash/pyutils',
-    packages=find_packages(exclude=["*.tests"]),
+    packages=find_packages(exclude=["tests*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
As per #28 (and #23), this is a one-line fix to stop `tests` folder from being installed via `pypi` etc. The syntax of `packages=find_packages(exclude=["*.tests"]),` was close; however, it needed to be `packages=find_packages(exclude=["tests*"]),` in the `setup.py` file in order to correctly remove the package from the distribution. This isn't documented that well and I had to search for a solution. I found it on [stackoverflow](https://stackoverflow.com/questions/608855/excluding-a-top-level-directory-from-a-setuptools-package) from 14+ years ago!

We can see that `tests` has been removed from the package via these checks:
```
$ python setup.py -q sdist
$ cat utils.egg-info/top_level.txt 
utils
$
```
This is an improvement and stops the issue once seen in other packages where they have the same error and hence the `.../tests/` folder conflicts under Python's `site-packages` folder. I was the author of that "other" package and it caused me some pain. I'm happy to pay-this-forward.

NOTE: I did not bump the version number; I believe that should be done by the author 
